### PR TITLE
Add Windows Crazyflie PWM runner

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -1,0 +1,32 @@
+cmake_minimum_required(VERSION 3.21)
+project(cf4pwm_runner_win LANGUAGES CXX)
+
+option(CFCPP_USE_FETCHCONTENT "Use FetchContent to get whoenig/crazyflie_cpp" ON)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(CFCPP_USE_FETCHCONTENT)
+  include(FetchContent)
+  FetchContent_Declare(crazyflie_cpp
+    GIT_REPOSITORY https://github.com/whoenig/crazyflie_cpp.git
+    GIT_TAG master
+  )
+  FetchContent_MakeAvailable(crazyflie_cpp)
+else()
+  add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../crazyflie_cpp crazyflie_cpp)
+endif()
+
+add_executable(cf4pwm_runner_win
+  src/main_win.cpp
+  src/udp_input.cpp
+  src/timing_win.cpp
+  src/metrics.cpp
+  src/radio_cfclient.cpp
+  src/pack.cpp
+)
+
+target_include_directories(cf4pwm_runner_win PRIVATE include)
+
+target_link_libraries(cf4pwm_runner_win PRIVATE crazyflie_cpp Ws2_32)
+

--- a/cpp/README.md
+++ b/cpp/README.md
@@ -1,0 +1,16 @@
+# cf4pwm Runner (Windows)
+
+High-rate PWM runner for Crazyflie, sending exactly one CRTP packet per tick.
+
+## Build
+
+```powershell
+cmake -S cpp -B cpp/build -G "Visual Studio 17 2022" -A x64 -DCMAKE_BUILD_TYPE=Release
+cmake --build cpp/build --config Release -j
+```
+
+## Run (500 Hz on core 3, high priority)
+
+```powershell
+cpp\build\Release\cf4pwm_runner_win.exe --uri "radio://0/80/2M" --rate 500 --affinity 3 --prio high --spin-tail
+```

--- a/cpp/include/cf4pwm/metrics.hpp
+++ b/cpp/include/cf4pwm/metrics.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <cstdint>
+#include <fstream>
+#include <vector>
+
+namespace cf4pwm {
+
+class Metrics {
+public:
+  Metrics(int64_t freq, const char* csvPath = nullptr);
+  void update(int64_t nowTicks, int64_t periodTicks, bool late);
+  void maybePrint(int64_t nowTicks);
+  void finish(int64_t nowTicks);
+
+private:
+  int64_t freq_;
+  std::vector<int64_t> ring_;
+  size_t ringPos_ = 0;
+  uint64_t samples_ = 0;
+  uint64_t late_ = 0;
+  int64_t lastTicks_ = 0;
+  int64_t lastPrintTicks_ = 0;
+  uint64_t samplesAtPrint_ = 0;
+  uint64_t lateAtPrint_ = 0;
+  int64_t minJitter_ = INT64_MAX;
+  int64_t maxJitter_ = INT64_MIN;
+  std::ofstream csv_;
+  int64_t startTicks_ = 0;
+};
+
+} // namespace cf4pwm
+

--- a/cpp/include/cf4pwm/pack.hpp
+++ b/cpp/include/cf4pwm/pack.hpp
@@ -1,0 +1,12 @@
+#pragma once
+
+#include <cstdint>
+
+namespace cf4pwm {
+
+uint64_t pack4u16(uint16_t a, uint16_t b, uint16_t c, uint16_t d) noexcept;
+void unpack4u16(uint64_t v, uint16_t &a, uint16_t &b, uint16_t &c, uint16_t &d) noexcept;
+void clamp4u16(uint16_t &a, uint16_t &b, uint16_t &c, uint16_t &d) noexcept;
+
+} // namespace cf4pwm
+

--- a/cpp/include/cf4pwm/radio_cfclient.hpp
+++ b/cpp/include/cf4pwm/radio_cfclient.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <string>
+
+namespace crazyflie_cpp {
+class Crazyflie;
+}
+
+namespace cf4pwm {
+
+class RadioClient {
+public:
+  bool init(const std::string& uri);
+  bool send4(uint16_t m1, uint16_t m2, uint16_t m3, uint16_t m4) noexcept;
+  void close() noexcept;
+
+private:
+  std::unique_ptr<crazyflie_cpp::Crazyflie> cf_;
+  std::array<uint8_t, 9> packet_{}; // header + 8 payload bytes
+};
+
+} // namespace cf4pwm
+

--- a/cpp/include/cf4pwm/timing_win.hpp
+++ b/cpp/include/cf4pwm/timing_win.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include <cstdint>
+
+namespace cf4pwm {
+
+struct RtConfig {
+  bool realtime{false};
+  unsigned long long affinityMask{0};
+  bool spinTail{false};
+};
+
+void init_timing(const RtConfig& cfg);
+void restore_timing();
+int64_t qpc_now();
+int64_t qpc_freq();
+int64_t secondsToTicks(double s, int64_t fq);
+double ticksToMs(int64_t t, int64_t fq);
+int64_t ticksToNs(int64_t t, int64_t fq);
+
+} // namespace cf4pwm
+

--- a/cpp/include/cf4pwm/udp_input.hpp
+++ b/cpp/include/cf4pwm/udp_input.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <thread>
+
+#ifdef _WIN32
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#endif
+
+namespace cf4pwm {
+
+struct PwmState {
+  std::atomic<uint64_t> packed{0};
+};
+
+class UdpInput {
+public:
+  UdpInput();
+  ~UdpInput();
+  bool start(PwmState* state);
+  void stop();
+
+private:
+#ifdef _WIN32
+  SOCKET sock_ = INVALID_SOCKET;
+#else
+  int sock_ = -1;
+#endif
+  std::thread thread_;
+  std::atomic<bool> running_{false};
+  PwmState* state_ = nullptr;
+};
+
+} // namespace cf4pwm
+

--- a/cpp/src/main_win.cpp
+++ b/cpp/src/main_win.cpp
@@ -1,0 +1,128 @@
+#include "cf4pwm/metrics.hpp"
+#include "cf4pwm/pack.hpp"
+#include "cf4pwm/radio_cfclient.hpp"
+#include "cf4pwm/timing_win.hpp"
+#include "cf4pwm/udp_input.hpp"
+
+#include <atomic>
+#include <iostream>
+#include <sstream>
+#include <string>
+#include <algorithm>
+#include <vector>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+using namespace cf4pwm;
+
+#ifndef _WIN32
+static inline void Sleep(unsigned long) {}
+#endif
+
+static std::atomic<bool> g_running{true};
+
+#ifdef _WIN32
+BOOL WINAPI consoleHandler(DWORD) {
+  g_running = false;
+  return TRUE;
+}
+#endif
+
+int main(int argc, char** argv) {
+  std::string uri = "radio://0/80/2M";
+  double rate = 500.0;
+  std::string affinityStr;
+  bool realtime = false;
+  bool spinTail = false;
+  const char* csvPath = nullptr;
+
+  for (int i = 1; i < argc; ++i) {
+    std::string arg = argv[i];
+    if (arg == "--uri" && i + 1 < argc) {
+      uri = argv[++i];
+    } else if (arg == "--rate" && i + 1 < argc) {
+      rate = std::stod(argv[++i]);
+    } else if (arg == "--affinity" && i + 1 < argc) {
+      affinityStr = argv[++i];
+    } else if (arg == "--prio" && i + 1 < argc) {
+      std::string p = argv[++i];
+      if (p == "realtime")
+        realtime = true;
+    } else if (arg == "--spin-tail") {
+      spinTail = true;
+    } else if (arg == "--csv" && i + 1 < argc) {
+      csvPath = argv[++i];
+    }
+  }
+
+#ifdef _WIN32
+  SetConsoleCtrlHandler(consoleHandler, TRUE);
+#endif
+
+  unsigned long long mask = 0;
+  if (!affinityStr.empty()) {
+    std::stringstream ss(affinityStr);
+    std::string token;
+    while (std::getline(ss, token, ',')) {
+      int core = std::stoi(token);
+      mask |= (1ull << core);
+    }
+  }
+
+  RtConfig cfg;
+  cfg.realtime = realtime;
+  cfg.affinityMask = mask;
+  cfg.spinTail = spinTail;
+  init_timing(cfg);
+
+  PwmState pwm;
+  UdpInput udp;
+  udp.start(&pwm);
+
+  RadioClient radio;
+  if (!radio.init(uri)) {
+    std::cerr << "radio init failed\n";
+    return 1;
+  }
+
+  int64_t fq = qpc_freq();
+  Metrics metrics(fq, csvPath);
+  double period_s = 1.0 / rate;
+  int64_t period_ticks = secondsToTicks(period_s, fq);
+  int64_t next = qpc_now();
+
+  while (g_running) {
+    uint16_t m1, m2, m3, m4;
+    unpack4u16(pwm.packed.load(std::memory_order_acquire), m1, m2, m3, m4);
+    radio.send4(m1, m2, m3, m4);
+
+    next += period_ticks;
+    int64_t now = qpc_now();
+    bool late = now > next;
+    metrics.update(now, period_ticks, late);
+
+    double slack_ms = ticksToMs(next - now, fq);
+    if (slack_ms > 0.6)
+      Sleep((DWORD)std::max(0.0, slack_ms - 0.3));
+    if (cfg.spinTail) {
+      while (qpc_now() < next) {
+      }
+    }
+    metrics.maybePrint(now);
+  }
+
+  for (int i = 0; i < 10; ++i) {
+    radio.send4(0, 0, 0, 0);
+    Sleep(10);
+  }
+
+  radio.close();
+  udp.stop();
+  int64_t endTicks = qpc_now();
+  metrics.finish(endTicks);
+  restore_timing();
+  return 0;
+}
+

--- a/cpp/src/metrics.cpp
+++ b/cpp/src/metrics.cpp
@@ -1,0 +1,96 @@
+#include "cf4pwm/metrics.hpp"
+#include "cf4pwm/timing_win.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <iomanip>
+#include <iostream>
+
+namespace cf4pwm {
+
+Metrics::Metrics(int64_t freq, const char* csvPath)
+    : freq_(freq), ring_(2048) {
+  if (csvPath) {
+    csv_.open(csvPath);
+    if (csv_) {
+      csv_ << "ts_ns,period_ns,jitter_ns,late\n";
+    }
+  }
+}
+
+void Metrics::update(int64_t nowTicks, int64_t periodTicks, bool late) {
+  if (startTicks_ == 0) {
+    startTicks_ = nowTicks;
+    lastTicks_ = nowTicks;
+    lastPrintTicks_ = nowTicks;
+    return;
+  }
+
+  int64_t actualTicks = nowTicks - lastTicks_;
+  lastTicks_ = nowTicks;
+  int64_t jitterTicks = actualTicks - periodTicks;
+  int64_t jitterNs = ticksToNs(jitterTicks, freq_);
+
+  ring_[ringPos_++] = std::llabs(jitterNs);
+  if (ringPos_ >= ring_.size())
+    ringPos_ = 0;
+
+  if (jitterNs < minJitter_)
+    minJitter_ = jitterNs;
+  if (jitterNs > maxJitter_)
+    maxJitter_ = jitterNs;
+
+  ++samples_;
+  if (late)
+    ++late_;
+
+  if (csv_) {
+    int64_t ts = ticksToNs(nowTicks - startTicks_, freq_);
+    int64_t periodNs = ticksToNs(actualTicks, freq_);
+    csv_ << ts << ',' << periodNs << ',' << jitterNs << ',' << (late ? 1 : 0)
+         << '\n';
+  }
+}
+
+void Metrics::maybePrint(int64_t nowTicks) {
+  int64_t elapsedTicks = nowTicks - lastPrintTicks_;
+  if (elapsedTicks < freq_)
+    return; // less than a second
+
+  uint64_t diffSamples = samples_ - samplesAtPrint_;
+  uint64_t diffLate = late_ - lateAtPrint_;
+  double hz = diffSamples * static_cast<double>(freq_) / elapsedTicks;
+  double latePct = diffSamples ? (100.0 * diffLate / diffSamples) : 0.0;
+
+  std::vector<int64_t> data = ring_;
+  std::sort(data.begin(), data.end());
+  auto pct = [&](double p) -> int64_t {
+    size_t idx = static_cast<size_t>(p * (data.size() - 1));
+    return data[idx];
+  };
+  int64_t p50 = pct(0.50);
+  int64_t p90 = pct(0.90);
+  int64_t p99 = pct(0.99);
+
+  std::cout << std::fixed << std::setprecision(1)
+            << "rate=" << hz << " Hz | late=" << latePct
+            << "% | jitter_us p50=" << p50 / 1000
+            << " p90=" << p90 / 1000
+            << " p99=" << p99 / 1000
+            << " max=" << maxJitter_ / 1000 << std::endl;
+
+  lastPrintTicks_ = nowTicks;
+  samplesAtPrint_ = samples_;
+  lateAtPrint_ = late_;
+  minJitter_ = INT64_MAX;
+  maxJitter_ = INT64_MIN;
+}
+
+void Metrics::finish(int64_t nowTicks) {
+  maybePrint(nowTicks);
+  if (csv_)
+    csv_.close();
+}
+
+} // namespace cf4pwm
+

--- a/cpp/src/pack.cpp
+++ b/cpp/src/pack.cpp
@@ -1,0 +1,27 @@
+#include "cf4pwm/pack.hpp"
+
+namespace cf4pwm {
+
+uint64_t pack4u16(uint16_t a, uint16_t b, uint16_t c, uint16_t d) noexcept {
+  return static_cast<uint64_t>(a) |
+         (static_cast<uint64_t>(b) << 16) |
+         (static_cast<uint64_t>(c) << 32) |
+         (static_cast<uint64_t>(d) << 48);
+}
+
+void unpack4u16(uint64_t v, uint16_t &a, uint16_t &b, uint16_t &c, uint16_t &d) noexcept {
+  a = static_cast<uint16_t>(v & 0xFFFF);
+  b = static_cast<uint16_t>((v >> 16) & 0xFFFF);
+  c = static_cast<uint16_t>((v >> 32) & 0xFFFF);
+  d = static_cast<uint16_t>((v >> 48) & 0xFFFF);
+}
+
+void clamp4u16(uint16_t &a, uint16_t &b, uint16_t &c, uint16_t &d) noexcept {
+  auto clamp = [](uint16_t &v) {
+    if (v > 65535) v = 65535;
+  };
+  clamp(a); clamp(b); clamp(c); clamp(d);
+}
+
+} // namespace cf4pwm
+

--- a/cpp/src/radio_cfclient.cpp
+++ b/cpp/src/radio_cfclient.cpp
@@ -1,0 +1,35 @@
+#include "cf4pwm/radio_cfclient.hpp"
+
+#include <crazyflie_cpp/Crazyflie.h>
+
+namespace cf4pwm {
+
+bool RadioClient::init(const std::string& uri) {
+  cf_ = std::make_unique<crazyflie_cpp::Crazyflie>(uri.c_str());
+  packet_[0] = 0xA0; // port 0x0A channel 0
+  return true;
+}
+
+bool RadioClient::send4(uint16_t m1, uint16_t m2, uint16_t m3, uint16_t m4) noexcept {
+  if (!cf_)
+    return false;
+  packet_[1] = static_cast<uint8_t>(m1 & 0xFF);
+  packet_[2] = static_cast<uint8_t>(m1 >> 8);
+  packet_[3] = static_cast<uint8_t>(m2 & 0xFF);
+  packet_[4] = static_cast<uint8_t>(m2 >> 8);
+  packet_[5] = static_cast<uint8_t>(m3 & 0xFF);
+  packet_[6] = static_cast<uint8_t>(m3 >> 8);
+  packet_[7] = static_cast<uint8_t>(m4 & 0xFF);
+  packet_[8] = static_cast<uint8_t>(m4 >> 8);
+  try {
+    cf_->sendPacket(packet_.data(), static_cast<uint8_t>(packet_.size()));
+    return true;
+  } catch (...) {
+    return false;
+  }
+}
+
+void RadioClient::close() noexcept { cf_.reset(); }
+
+} // namespace cf4pwm
+

--- a/cpp/src/timing_win.cpp
+++ b/cpp/src/timing_win.cpp
@@ -1,0 +1,74 @@
+#include "cf4pwm/timing_win.hpp"
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace cf4pwm {
+namespace {
+bool g_timePeriod = false;
+}
+
+void init_timing(const RtConfig& cfg) {
+#ifdef _WIN32
+  timeBeginPeriod(1);
+  g_timePeriod = true;
+  HANDLE proc = GetCurrentProcess();
+  SetPriorityClass(proc, cfg.realtime ? REALTIME_PRIORITY_CLASS : HIGH_PRIORITY_CLASS);
+  HANDLE th = GetCurrentThread();
+  SetThreadPriority(th, THREAD_PRIORITY_TIME_CRITICAL);
+  if (cfg.affinityMask) {
+    SetProcessAffinityMask(proc, static_cast<DWORD_PTR>(cfg.affinityMask));
+    SetThreadAffinityMask(th, static_cast<DWORD_PTR>(cfg.affinityMask));
+  }
+#else
+  (void)cfg;
+#endif
+}
+
+void restore_timing() {
+#ifdef _WIN32
+  if (g_timePeriod) {
+    timeEndPeriod(1);
+    g_timePeriod = false;
+  }
+#endif
+}
+
+int64_t qpc_now() {
+#ifdef _WIN32
+  LARGE_INTEGER v;
+  QueryPerformanceCounter(&v);
+  return v.QuadPart;
+#else
+  return 0;
+#endif
+}
+
+int64_t qpc_freq() {
+#ifdef _WIN32
+  static int64_t f = []() {
+    LARGE_INTEGER v;
+    QueryPerformanceFrequency(&v);
+    return v.QuadPart;
+  }();
+  return f;
+#else
+  return 1;
+#endif
+}
+
+int64_t secondsToTicks(double s, int64_t fq) {
+  return static_cast<int64_t>(s * static_cast<double>(fq));
+}
+
+double ticksToMs(int64_t t, int64_t fq) {
+  return static_cast<double>(t) * 1000.0 / static_cast<double>(fq);
+}
+
+int64_t ticksToNs(int64_t t, int64_t fq) {
+  return static_cast<int64_t>(static_cast<double>(t) * 1e9 / static_cast<double>(fq));
+}
+
+} // namespace cf4pwm
+

--- a/cpp/src/udp_input.cpp
+++ b/cpp/src/udp_input.cpp
@@ -1,0 +1,94 @@
+#include "cf4pwm/udp_input.hpp"
+#include "cf4pwm/pack.hpp"
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+#include <cstring>
+
+namespace cf4pwm {
+
+UdpInput::UdpInput() {}
+UdpInput::~UdpInput() { stop(); }
+
+bool UdpInput::start(PwmState* state) {
+#ifdef _WIN32
+  state_ = state;
+  WSADATA wsa;
+  if (WSAStartup(MAKEWORD(2, 2), &wsa) != 0)
+    return false;
+
+  sock_ = socket(AF_INET, SOCK_DGRAM, IPPROTO_UDP);
+  if (sock_ == INVALID_SOCKET)
+    return false;
+
+  sockaddr_in addr{};
+  addr.sin_family = AF_INET;
+  addr.sin_addr.s_addr = INADDR_ANY;
+  addr.sin_port = htons(8888);
+  if (bind(sock_, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)) == SOCKET_ERROR)
+    return false;
+
+  u_long mode = 1;
+  ioctlsocket(sock_, FIONBIO, &mode);
+
+  running_ = true;
+  thread_ = std::thread([this]() {
+    uint8_t buf[16];
+    while (running_) {
+      int ret = recv(sock_, reinterpret_cast<char*>(buf), sizeof(buf), 0);
+      if (ret == SOCKET_ERROR) {
+        int err = WSAGetLastError();
+        if (err == WSAEWOULDBLOCK) {
+          Sleep(1);
+          continue;
+        } else {
+          break;
+        }
+      }
+      if (ret == 8) {
+        uint16_t m1 = buf[0] | (buf[1] << 8);
+        uint16_t m2 = buf[2] | (buf[3] << 8);
+        uint16_t m3 = buf[4] | (buf[5] << 8);
+        uint16_t m4 = buf[6] | (buf[7] << 8);
+        uint64_t packed = pack4u16(m1, m2, m3, m4);
+        state_->packed.store(packed, std::memory_order_release);
+      } else if (ret == 16) {
+        float f[4];
+        std::memcpy(f, buf, 16);
+        uint16_t m[4];
+        for (int i = 0; i < 4; ++i) {
+          float v = f[i];
+          if (v < 0.f)
+            v = 0.f;
+          if (v > 65535.f)
+            v = 65535.f;
+          m[i] = static_cast<uint16_t>(v);
+        }
+        uint64_t packed = pack4u16(m[0], m[1], m[2], m[3]);
+        state_->packed.store(packed, std::memory_order_release);
+      }
+    }
+  });
+  return true;
+#else
+  (void)state;
+  return false;
+#endif
+}
+
+void UdpInput::stop() {
+#ifdef _WIN32
+  running_ = false;
+  if (thread_.joinable())
+    thread_.join();
+  if (sock_ != INVALID_SOCKET) {
+    closesocket(sock_);
+    sock_ = INVALID_SOCKET;
+  }
+  WSACleanup();
+#endif
+}
+
+} // namespace cf4pwm
+


### PR DESCRIPTION
## Summary
- Add `cpp` Windows runner that streams one CRTP packet per tick to Crazyflie
- Implement UDP input, timing helpers, metrics and radio wrapper using crazyflie_cpp
- Provide CMake setup with FetchContent for crazyflie_cpp and link against Ws2_32

## Testing
- `cmake -S cpp -B cpp/build` *(fails: unable to clone crazyflie_cpp due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_68b353ce15188330ad928f1883df3604