### PR TITLE
Add VS Code configuration for Windows C++ runner

### DIFF
--- a/cpp/.vscode/launch.json
+++ b/cpp/.vscode/launch.json
@@ -1,0 +1,20 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Run cf4pwm (Release)",
+      "type": "cppvsdbg",
+      "request": "launch",
+      "program": "${command:cmake.launchTargetPath}",
+      "args": [
+        "--uri", "radio://0/80/2M",
+        "--rate", "500",
+        "--affinity", "3",
+        "--prio", "high",
+        "--spin-tail"
+      ],
+      "cwd": "${workspaceFolder}",
+      "console": "integratedTerminal"
+    }
+  ]
+}

--- a/cpp/.vscode/settings.json
+++ b/cpp/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "cmake.generator": "Visual Studio 17 2022",
+  "cmake.buildDirectory": "${workspaceFolder}/build/${buildType}",
+  "cmake.buildType": "Release",
+  "cmake.configureOnOpen": true,
+  "C_Cpp.default.configurationProvider": "ms-vscode.cmake-tools",
+  "cmake.sourceDirectory": "${workspaceFolder}",
+  "cmake.environment": {
+    "VCPKG_ROOT": "${env:VCPKG_ROOT}"
+  }
+}

--- a/cpp/.vscode/tasks.json
+++ b/cpp/.vscode/tasks.json
@@ -1,0 +1,40 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "CMake: Configure",
+      "type": "cmake",
+      "command": "configure",
+      "problemMatcher": []
+    },
+    {
+      "label": "CMake: Build (Release)",
+      "type": "cmake",
+      "command": "build",
+      "targets": [ "cf4pwm_runner_win" ],
+      "group": { "kind": "build", "isDefault": true },
+      "problemMatcher": []
+    },
+    {
+      "label": "CMake: Clean",
+      "type": "cmake",
+      "command": "clean",
+      "problemMatcher": []
+    },
+    {
+      "label": "Run cf4pwm (Release)",
+      "type": "shell",
+      "dependsOn": [ "CMake: Build (Release)" ],
+      "command": "${command:cmake.launchTargetPath}",
+      "args": [
+        "--uri", "radio://0/80/2M",
+        "--rate", "500",
+        "--affinity", "3",
+        "--prio", "high",
+        "--spin-tail"
+      ],
+      "options": { "cwd": "${workspaceFolder}" },
+      "problemMatcher": []
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- add VS Code `settings.json` to configure CMake for Visual Studio and VCPKG
- add `launch.json` to run cf4pwm with default radio parameters
- add `tasks.json` for configure, build, clean, and run commands

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'cflib')*

------
https://chatgpt.com/codex/tasks/task_e_68b35b1c559483309639d2c13295850a