### PR TITLE
Fix MSVC build flags and chrono literals

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -13,8 +13,17 @@ if(CFCPP_USE_FETCHCONTENT)
     GIT_TAG master
   )
   FetchContent_MakeAvailable(crazyflie_cpp)
+  if(MSVC)
+    get_target_property(CFCPP_COMPILE_OPTIONS crazyflie_cpp INTERFACE_COMPILE_OPTIONS)
+    if(CFCPP_COMPILE_OPTIONS)
+      list(REMOVE_ITEM CFCPP_COMPILE_OPTIONS -Wall -Wextra -Werror)
+      set_property(TARGET crazyflie_cpp PROPERTY INTERFACE_COMPILE_OPTIONS "${CFCPP_COMPILE_OPTIONS}")
+    endif()
+    target_compile_options(crazyflie_cpp INTERFACE /W3)
+  endif()
 else()
   add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../crazyflie_cpp crazyflie_cpp)
+  set(crazyflie_cpp_SOURCE_DIR ${CMAKE_CURRENT_SOURCE_DIR}/../crazyflie_cpp)
 endif()
 
 add_executable(cf4pwm_runner_win
@@ -26,7 +35,15 @@ add_executable(cf4pwm_runner_win
   src/pack.cpp
 )
 
-target_include_directories(cf4pwm_runner_win PRIVATE include)
+target_include_directories(cf4pwm_runner_win
+  PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}/include
+    ${crazyflie_cpp_SOURCE_DIR}/include
+)
+
+if(MSVC)
+  target_compile_definitions(cf4pwm_runner_win PRIVATE NOMINMAX)
+endif()
 
 target_link_libraries(cf4pwm_runner_win PRIVATE crazyflie_cpp Ws2_32)
 

--- a/cpp/src/main_win.cpp
+++ b/cpp/src/main_win.cpp
@@ -10,11 +10,13 @@
 #include <string>
 #include <algorithm>
 #include <vector>
+#include <chrono>
 
 #ifdef _WIN32
 #include <windows.h>
 #endif
 
+using namespace std::chrono_literals;
 using namespace cf4pwm;
 
 #ifndef _WIN32


### PR DESCRIPTION
## Summary
- Fix crazyflie_cpp warning flags for MSVC and add NOMINMAX
- Add crazyflie_cpp include directory and chrono literal support

## Testing
- `cmake -S cpp -B cpp/build` *(fails: CONNECT tunnel failed, response 403 while cloning crazyflie_cpp)*

------
https://chatgpt.com/codex/tasks/task_e_68b40a91a8d88330badd8041b251b15c