### PR TITLE
Integrate Crazyflie library with MSVC shims

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -6,7 +6,13 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
 if (MSVC)
-  add_definitions(-DWIN32_LEAN_AND_MEAN -DNOMINMAX -D_CRT_SECURE_NO_WARNINGS)
+  add_compile_definitions(
+    WIN32_LEAN_AND_MEAN
+    NOMINMAX
+    _CRT_SECURE_NO_WARNINGS
+    _USE_MATH_DEFINES
+    WINDOWS_IGNORE_PACKING_MISMATCH
+  )
   add_compile_options(/permissive-)
 endif()
 
@@ -19,6 +25,7 @@ FetchContent_Declare(
   GIT_TAG        master
 )
 FetchContent_MakeAvailable(crazyflie_cpp)
+find_package(libusb-1.0 CONFIG REQUIRED)
 
 # --- MSVC: strip any -W* flags from upstream targets (both PUBLIC/INTERFACE) ---
 if (MSVC)
@@ -52,12 +59,19 @@ target_include_directories(cf4pwm_runner_win PRIVATE
   ${_cf_src_dir}/include/crazyflie_cpp
 )
 
-target_link_libraries(cf4pwm_runner_win PRIVATE crazyflie_cpp)
+target_link_libraries(cf4pwm_runner_win PRIVATE crazyflie_cpp libusb-1.0::libusb-1.0)
+if (TARGET crazyflie_cpp)
+  target_link_libraries(crazyflie_cpp PRIVATE libusb-1.0::libusb-1.0)
+endif()
 
 if (MSVC)
   target_compile_options(cf4pwm_runner_win PRIVATE /W3)
 else()
   target_compile_options(cf4pwm_runner_win PRIVATE -Wall -Wextra)
+endif()
+
+if (MSVC)
+  _strip_gcc_warnings(cf4pwm_runner_win)
 endif()
 
 set_target_properties(cf4pwm_runner_win PROPERTIES
@@ -67,14 +81,15 @@ set_target_properties(cf4pwm_runner_win PROPERTIES
 # --- MSVC: force-include shim into our exe and upstream targets to fix ssize_t & GNU attributes ---
 if (MSVC)
   set(_shim "${CMAKE_CURRENT_SOURCE_DIR}/include/cf4pwm/msvc_posix_attr_shim.hpp")
+  file(TO_CMAKE_PATH "${_shim}" MSVC_SHIM)
 
   # our app
-  target_compile_options(cf4pwm_runner_win PRIVATE /FI"${_shim}")
+  target_compile_options(cf4pwm_runner_win PRIVATE /FI${MSVC_SHIM})
 
   # upstream libs (if the targets exist, apply the same)
   foreach(dep IN ITEMS crazyflie_cpp crazyradio)
     if (TARGET ${dep})
-      target_compile_options(${dep} PRIVATE /FI"${_shim}")
+      target_compile_options(${dep} PRIVATE /FI${MSVC_SHIM})
     endif()
   endforeach()
 endif()

--- a/cpp/include/cf4pwm/msvc_pack_pop.hpp
+++ b/cpp/include/cf4pwm/msvc_pack_pop.hpp
@@ -1,0 +1,3 @@
+#pragma once
+// Restore default packing for any local packed structs
+#pragma pack(pop)

--- a/cpp/include/cf4pwm/msvc_posix_attr_shim.hpp
+++ b/cpp/include/cf4pwm/msvc_posix_attr_shim.hpp
@@ -1,19 +1,13 @@
 #pragma once
-#ifdef _MSC_VER
-  // Provide ssize_t on MSVC (64-bit)
-  #include <basetsd.h>
-  #ifndef ssize_t
-    typedef SSIZE_T ssize_t;
-  #endif
-
-  // Make GNU-style attributes no-ops on MSVC; guard to avoid redefinitions
-  #ifndef __attribute__
-    #define __attribute__(x)
-  #endif
-  #ifndef __packed
-    #define __packed
-  #endif
-  #ifndef packed
-    #define packed
-  #endif
+// Neutralize GNU-style attributes on MSVC
+#ifndef __attribute__
+#define __attribute__(...)
 #endif
+// Provide ssize_t via BaseTsd.h
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+// Enable math constants like M_SQRT1_2
+#ifndef _USE_MATH_DEFINES
+#define _USE_MATH_DEFINES
+#endif
+#include <cmath>


### PR DESCRIPTION
## Summary
- add MSVC shim headers for GNU attributes and packing
- refactor RadioClient to use Crazyflie library and send 4xPWM packets
- fetch crazyflie_cpp via CMake and link libusb

## Testing
- `vcpkg install libusb:x64-windows` *(fails: command not found)*
- `cmake -S cpp -B cpp/build -G Ninja -DCMAKE_BUILD_TYPE=Release -DCMAKE_TOOLCHAIN_FILE=C:/vcpkg/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=x64-windows` *(fails: Could not find toolchain file & Ninja)*
- `cmake --build cpp/build -j8` *(fails: No such file or directory)*
- `cpp/build/bin/cf4pwm_runner_win.exe --uri "radio://0/80/2M" --rate 500 --affinity 3 --prio high --spin-tail` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b41e5280f08330b7e9808a54ba1e71