### PR TITLE
Enable Windows MSVC build with crazyflie_cpp and vcpkg libusb

### DIFF
--- a/cpp/CMakeLists.txt
+++ b/cpp/CMakeLists.txt
@@ -19,7 +19,7 @@ endif()
 include(FetchContent)
 set(FETCHCONTENT_QUIET OFF)
 
-# ---------- vcpkg: 找 libusb ----------
+# ---------- vcpkg: libusb ----------
 if(NOT DEFINED VCPKG_ROOT)
   if(DEFINED ENV{VCPKG_ROOT})
     set(VCPKG_ROOT "$ENV{VCPKG_ROOT}")
@@ -47,16 +47,15 @@ endif()
 message(STATUS "Found libusb include: ${LIBUSB_INCLUDE_DIR}")
 message(STATUS "Found libusb lib:     ${LIBUSB_LIBRARY}")
 
-# 也把上游常見變數一併預先設好（有些版本會用到）
-set(USB_FOUND         TRUE                          CACHE BOOL     "libusb found"       FORCE)
-set(USB_INCLUDE_DIR   "${LIBUSB_INCLUDE_DIR}"       CACHE PATH     "libusb include dir" FORCE)
-set(USB_INCLUDE_DIRS  "${LIBUSB_INCLUDE_DIR}"       CACHE PATH     "libusb include dir" FORCE)
-set(USB_LIBRARY       "${LIBUSB_LIBRARY}"           CACHE FILEPATH "libusb library"     FORCE)
-set(USB_LIBRARIES     "${LIBUSB_LIBRARY}"           CACHE FILEPATH "libusb libraries"   FORCE)
-set(USB_LIB           "${LIBUSB_LIBRARY}"           CACHE FILEPATH "libusb library"     FORCE)
+# Provide common USB cache vars for upstream (some versions read these)
+set(USB_FOUND         TRUE                    CACHE BOOL     "libusb found"       FORCE)
+set(USB_INCLUDE_DIR   "${LIBUSB_INCLUDE_DIR}" CACHE PATH     "libusb include dir" FORCE)
+set(USB_INCLUDE_DIRS  "${LIBUSB_INCLUDE_DIR}" CACHE PATH     "libusb include dir" FORCE)
+set(USB_LIBRARY       "${LIBUSB_LIBRARY}"     CACHE FILEPATH "libusb library"     FORCE)
+set(USB_LIBRARIES     "${LIBUSB_LIBRARY}"     CACHE FILEPATH "libusb libraries"   FORCE)
+set(USB_LIB           "${LIBUSB_LIBRARY}"     CACHE FILEPATH "libusb library"     FORCE)
 
-# ---------- 抓取 crazyflie_cpp ----------
-# 用 CMAKE_CACHE_ARGS 確保子組態能收到 USB_* 參數
+# ---------- Fetch whoenig/crazyflie_cpp ----------
 FetchContent_Declare(
   crazyflie_cpp
   GIT_REPOSITORY https://github.com/whoenig/crazyflie_cpp.git
@@ -71,7 +70,7 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(crazyflie_cpp)
 
-# MSVC：移除上游遺留的 GCC 警告旗標，避免 MSVC 誤判
+# Strip GCC -W* flags when using MSVC (avoid invalid options)
 if (MSVC)
   function(_strip_gcc_warnings tgt)
     if (TARGET ${tgt})
@@ -85,10 +84,10 @@ if (MSVC)
     endif()
   endfunction()
   _strip_gcc_warnings(crazyflie_cpp)
-  _strip_gcc_warnings(crazyradio)
+  _strip_gcc_warnings(crazyradio) # if upstream defines it
 endif()
 
-# ---------- 我們的執行檔 ----------
+# ---------- Executable ----------
 add_executable(cf4pwm_runner_win
   src/main_win.cpp
   src/radio_cfclient.cpp
@@ -98,7 +97,7 @@ add_executable(cf4pwm_runner_win
   src/udp_input.cpp
 )
 
-# include 路徑
+# Include paths (our headers + upstream + libusb)
 set(_cf_src_dir "${crazyflie_cpp_SOURCE_DIR}")
 target_include_directories(cf4pwm_runner_win PRIVATE
   "${CMAKE_CURRENT_SOURCE_DIR}/include"
@@ -107,31 +106,35 @@ target_include_directories(cf4pwm_runner_win PRIVATE
   "${LIBUSB_INCLUDE_DIR}"
 )
 
-# 連結上游 + libusb + Winsock（udp_input 需要）
+# Ensure crazyflie_cpp sees libusb includes/libs, and enforce MSVC packing
+if (TARGET crazyflie_cpp)
+  target_include_directories(crazyflie_cpp PRIVATE "${LIBUSB_INCLUDE_DIR}")
+  target_link_libraries(crazyflie_cpp     PRIVATE "${LIBUSB_LIBRARY}")
+  if (MSVC)
+    target_compile_options(crazyflie_cpp PRIVATE "/I${LIBUSB_INCLUDE_DIR}")
+    target_compile_options(crazyflie_cpp PRIVATE /Zp1)   # 1-byte struct packing to satisfy CRTP packet sizes
+  endif()
+endif()
+
+# Link upstream + libusb + Winsock + WinMM
 if (WIN32)
-  target_link_libraries(cf4pwm_runner_win PRIVATE crazyflie_cpp "${LIBUSB_LIBRARY}" Ws2_32)
+  target_link_libraries(cf4pwm_runner_win PRIVATE crazyflie_cpp "${LIBUSB_LIBRARY}" Ws2_32 Winmm)
 else()
   target_link_libraries(cf4pwm_runner_win PRIVATE crazyflie_cpp "${LIBUSB_LIBRARY}")
 endif()
 
-# 輸出目錄
+# Output dir
 set_target_properties(cf4pwm_runner_win PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/bin"
 )
 
-# ---------- MSVC 特殊處理 ----------
+# ---------- MSVC: force-include POSIX attr shim on both targets ----------
 if (MSVC)
-  # 強制包含 shim（純相容：不動 pack）
   get_filename_component(_shim_abs
     "${CMAKE_CURRENT_SOURCE_DIR}/include/cf4pwm/msvc_posix_attr_shim.hpp" ABSOLUTE)
   target_compile_options(cf4pwm_runner_win PRIVATE /FI"${_shim_abs}")
   if (TARGET crazyflie_cpp)
     target_compile_options(crazyflie_cpp PRIVATE /FI"${_shim_abs}")
-  endif()
-
-  # 關鍵：讓 crazyflie_cpp 以 1-byte 對齊，避免 CRTP 封包大小 assert
-  if (TARGET crazyflie_cpp)
-    target_compile_options(crazyflie_cpp PRIVATE /Zp1)
   endif()
 
   target_compile_options(cf4pwm_runner_win PRIVATE /W3)


### PR DESCRIPTION
## Summary
- configure CMake to fetch crazyflie_cpp and use vcpkg-provided libusb
- link Winsock/WinMM, strip GCC flags, and force pack/posix shim for MSVC

## Testing
- `C:\vcpkg\vcpkg.exe install libusb:x64-windows` *(fails: command not found)*
- `cmake -S . -B build\Debug -G "Visual Studio 17 2022"` *(fails: generator not available)*
- `cmake --build build\Debug --config Debug -j` *(fails: directory not found because configure step failed)*

------
https://chatgpt.com/codex/tasks/task_e_68b43ec8cd0483308e406d1ced86454d